### PR TITLE
VP-4021: Fix get-image-version action fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,20 @@ name: CI
 # events but only for the master branch
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -68,7 +80,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Get Image Version
-      uses: VirtoCommerce/vc-github-actions/get-image-version@master
+      uses: VirtoCommerce/vc-github-actions/get-image-version@dev
       id: image
 
     - name: Install VirtoCommerce.GlobalTool


### PR DESCRIPTION
Changed get-image-version action version to dev
Added path-ignore for push and PR events